### PR TITLE
fix md config typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ npm install
 Copy the contents from `sample-config.json` to `config.json`:
 
 ```bash
-$ cp sample-confog.json config.json
+$ cp sample-config.json config.json
 
 ```
 


### PR DESCRIPTION
Fix a typo in the bash copy instructions